### PR TITLE
Add alert component

### DIFF
--- a/src/kushi/colors.cljc
+++ b/src/kushi/colors.cljc
@@ -1,4 +1,5 @@
-(ns ^:dev/always kushi.colors)
+(ns ^:dev/always kushi.colors
+    (:require [clojure.set :as set :refer [map-invert]]))
 
 (def colors
   [
@@ -129,3 +130,13 @@
             [900 37 24]
             [1000 40 11]]}
    ])
+
+(def colors-by-alias
+  (into {}
+        (keep (fn [[k v]]
+                (when-let [alias (:alias v)]
+                  [alias k]))
+              (partition 2 colors))))
+
+(def aliases-by-color
+  (map-invert colors-by-alias))

--- a/src/kushi/core.clj
+++ b/src/kushi/core.clj
@@ -312,7 +312,13 @@
 (defn sx-dispatch
   [{:keys [form-meta args]
     :or   {form-meta {}}}]
-  (let [cache-map (state2/cached {:process :sx
+
+  (when @state2/KUSHIDEBUG (state2/trace-mode! args))
+
+  (let [args      (if (and @state2/KUSHIDEBUG (state2/trace-mode?))
+                    (drop-last args)
+                    args)
+        cache-map (state2/cached {:process :sx
                                   :args    args})
         process   (process args)
         clean     (or (:cached cache-map)

--- a/src/kushi/state2.clj
+++ b/src/kushi/state2.clj
@@ -1,5 +1,6 @@
 (ns ^:dev/always kushi.state2
   (:require
+[par.core :refer [!? ?]]
    [clojure.data :as data]
    [kushi.io :refer [load-edn]]
    [clojure.java.io :refer [make-parents]]
@@ -14,6 +15,7 @@
 (def shadow-build-id (atom nil))
 (def initial-build? (atom true))
 (def trace?* (atom false))
+(def *trace-mode? (atom false))
 
 (def css (atom []))
 (def ->css (atom nil))
@@ -109,6 +111,8 @@
 (defn trace! [args target] (reset! trace?* (= args (rest target))) )
 (defn trace? [] @trace?*)
 
+(defn trace-mode! [args] (reset! *trace-mode? (= (last args) :kushi/trace)))
+(defn trace-mode? [] @*trace-mode?)
 
 ;; Caching and hashing ---------------------------------------------------
 (defn cached

--- a/src/kushi/state2.clj
+++ b/src/kushi/state2.clj
@@ -1,6 +1,5 @@
 (ns ^:dev/always kushi.state2
   (:require
-[par.core :refer [!? ?]]
    [clojure.data :as data]
    [kushi.io :refer [load-edn]]
    [clojure.java.io :refer [make-parents]]

--- a/src/kushi/ui/alert/core.cljs
+++ b/src/kushi/ui/alert/core.cljs
@@ -1,0 +1,69 @@
+(ns kushi.ui.alert.core
+  (:require [kushi.core :refer (merge-attrs) :refer-macros [sx]]
+            [kushi.ui.label.core :refer [label]]
+            [kushi.ui.core :refer (opts+children)]))
+
+(defn alert
+  {:desc ["Alerts provide contextual feedback information for the user"]
+   :opts '[{:name    mui-icon
+            :type    :string
+            :default nil
+            :desc    ["Places an icon anchored to the inline-start area of the alert."
+                      "Must be a string corresponding to a [mui-icon](https://fonts.google.com/icons?icon.set=Material+Icons)."]}
+           {:name    mui-icon-style
+            :type    #{:filled :outlined :rounded :sharp}
+            :default :filled
+            :desc    "Controls the style of the [mui-icon](https://fonts.google.com/icons?icon.set=Material+Icons)."}
+           {:name    icon-svg
+            :type    :boolean
+            :default false
+            :desc    ["Pass a `mui-icon` in `svg` (hiccup) to use in place of the Google Fonts Material Icons font."
+                      "Must use `:viewBox` attribute with values such as `\"0 0 24 24\"`."
+                      "The `:width` and `:height` attributes of the `svg` do not need to be set."]}
+           {:name    close-icon?
+            :type    :boolean
+            :default nil
+            :desc    "Places a close \"×\" icon anchored to the inline-end area of the alert."}
+           {:name    close-icon-attrs
+            :type    :map
+            :default nil
+            :desc    "Attributes map for close-icon. This is where you would put your click-handler for closing the alert."}]}
+  [& args]
+  (let [[opts attrs & children]   (opts+children args)
+        {:keys [mui-icon-style
+                close-icon?
+                close-icon-attrs]
+         mi    :mui-icon} opts]
+    [:section
+     (merge-attrs
+      (sx 'kushi-alert
+          :.info
+          :p--1rem
+          :w--100%
+          {:data-kushi-ui :alert})
+      attrs)
+     [:div (sx :.flex-row-fs
+               :ai--c
+               :.relative
+               :w--100%)
+      [label (sx (when-not mi :.hidden)
+                 {:-mui-icon       (or mi :info)
+                  :-mui-icon-style mui-icon-style})]
+      (if (every? string? children)
+        [label (sx :flex-grow--1 :ta--c) children]
+        (into [:span (sx :flex-grow--1 :ta--c)] children))
+      (when close-icon?
+        (let [hover-bgc "rgba 255 255 255 0.3"]
+          [label (merge-attrs
+                  (sx :.pointer
+                      :.pill
+                      :outline-width--3px
+                      :outline-style--style
+                      :outline-color--transparent
+                      [:outline-color hover-bgc]
+                      [:hover:bgc hover-bgc]
+                      {:tab-index      0
+                       :role           :button
+                       :-mui-icon      :close
+                       :-icon-position :inline-end})
+                  close-icon-attrs)]))]]))

--- a/src/kushi/ui/examples.cljs
+++ b/src/kushi/ui/examples.cljs
@@ -6,6 +6,7 @@
    [kushi.ui.input.checkbox.core :refer (checkbox)]
    [kushi.ui.input.text.core :refer (input)]
    [kushi.ui.input.slider.core :refer (slider)]
+   [kushi.ui.alert.core :refer (alert)]
    [kushi.ui.grid.core :refer (grid)]
    [kushi.ui.icon.mui.core :refer (mui-icon)]
    [kushi.ui.tag.core :refer (tag)]
@@ -55,7 +56,7 @@
               ;;                                  {:-mui-icon      :play-arrow
               ;;                                   :-icon-position :inline-end})
               ;;                       "Play"])}
-
+               
                {:label   "Icon button"
                 :example (example2 [button (sx  {:-mui-icon :play-arrow})])}
 
@@ -97,7 +98,8 @@
                                               :&_.kushi-radio-input:checked+.kushi-label>.emoji:transform "scale(1.5)"
                                               :&_.kushi-radio-input:checked+.kushi-label>.emoji:animation :jiggle2:0.5s}})
                                     [radio
-                                     {:-input-attrs {:name :demo :defaultChecked true}} [label [:span.emoji "🦑"] "Squid"]]
+                                     {:-input-attrs {:name           :demo
+                                                     :defaultChecked true}} [label [:span.emoji "🦑"] "Squid"]]
                                     [radio {:-input-attrs {:name :demo}} [label [:span.emoji "🐋"] "Whale"]]
                                     [radio {:-input-attrs {:name :demo}} [label [:span.emoji "🦈 "] "Shark"]]
                                     [radio {:-input-attrs {:name :demo}} [label [:span.emoji "🐊"] "Croc"]]])}]}
@@ -135,7 +137,7 @@
                                                :-label      "Input label"})])}
                {:label   "Disabled"
                 :example (example2 [input (sx {:placeholder "Your text here"
-                                               :disabled   true
+                                               :disabled    true
                                                :-label      "Input label"})])}
                {:label   "With helper"
                 :example (example2 [input (sx {:placeholder "Your text here"
@@ -181,50 +183,50 @@
                                                                          {:class :my-input-wrapper-name})
                                                })])}]}
 
-   {:fn      slider
-    :meta    #'slider
-    :stage   {:style {:min-height :135px}}
+   {:fn       slider
+    :meta     #'slider
+    :stage    {:style {:min-height :135px}}
     :defaults {:examples "Simple"}
-    :content [{:label   "Simple"
-               :example (example2 [slider {:min 0
-                                           :max 7}])}
-              {:label   "Lables"
-               :example (example2 [slider {:min          0
-                                           :max          7
-                                           :-step-marker :label}])}
-              {:label   "Dot markers"
-               :example (example2 [slider {:min          0
-                                           :max          7
-                                           :-step-marker :dot}])}
-              {:label   "Bar markers"
-               :example (example2 [slider {:min          0
-                                           :max          7
-                                           :-step-marker :bar}])}
-              {:label   "Fractional step"
-               :example (example2 [slider {:min  0
-                                           :max  1
-                                           :step 0.01}])}
-              {:label   "Supplied step values"
-               :example (example2 [slider {:-steps            ["xsmall" "medium" "large" "xlarge"]
-                                           :-step-marker      :label
-                                           :-label-size-class :medium}])}
-              #_{:label   "Supplied step values, custom label styling"
-               :example (example2 [slider {:-steps              ["low" "guarded" "elevated" "high" "severe"]
-                                           :-step-marker        :label
-                                           :-label-size-class   :small
-                                           :-label-scale-factor 0.8
-                                           :-labels-attrs       (sx :>span>span:border-radius--9999px
-                                                                    :>span>span:padding--0.125em:0.75em:0.2em
-                                                                    {:style {">span:nth-child(1):c"         :$positive
-                                                                             ">span:nth-child(1):>span:bgc" :$positive50
-                                                                             ">span:nth-child(2):c"         :$accent
-                                                                             ">span:nth-child(2):>span:bgc" :$accent50
-                                                                             ">span:nth-child(3):c"         :$warning
-                                                                             ">span:nth-child(3):>span:bgc" :$warning50
-                                                                             ">span:nth-child(4):c"         :$orange700
-                                                                             ">span:nth-child(4):>span:bgc" :$orange50
-                                                                             ">span:nth-child(5):c"         :$negative
-                                                                             ">span:nth-child(5):>span:bgc" :$negative50}})}])}]}
+    :content  [{:label   "Simple"
+                :example (example2 [slider {:min 0
+                                            :max 7}])}
+               {:label   "Lables"
+                :example (example2 [slider {:min          0
+                                            :max          7
+                                            :-step-marker :label}])}
+               {:label   "Dot markers"
+                :example (example2 [slider {:min          0
+                                            :max          7
+                                            :-step-marker :dot}])}
+               {:label   "Bar markers"
+                :example (example2 [slider {:min          0
+                                            :max          7
+                                            :-step-marker :bar}])}
+               {:label   "Fractional step"
+                :example (example2 [slider {:min  0
+                                            :max  1
+                                            :step 0.01}])}
+               {:label   "Supplied step values"
+                :example (example2 [slider {:-steps            ["xsmall" "medium" "large" "xlarge"]
+                                            :-step-marker      :label
+                                            :-label-size-class :medium}])}
+               #_{:label   "Supplied step values, custom label styling"
+                  :example (example2 [slider {:-steps              ["low" "guarded" "elevated" "high" "severe"]
+                                              :-step-marker        :label
+                                              :-label-size-class   :small
+                                              :-label-scale-factor 0.8
+                                              :-labels-attrs       (sx :>span>span:border-radius--9999px
+                                                                       :>span>span:padding--0.125em:0.75em:0.2em
+                                                                       {:style {">span:nth-child(1):c"         :$positive
+                                                                                ">span:nth-child(1):>span:bgc" :$positive50
+                                                                                ">span:nth-child(2):c"         :$accent
+                                                                                ">span:nth-child(2):>span:bgc" :$accent50
+                                                                                ">span:nth-child(3):c"         :$warning
+                                                                                ">span:nth-child(3):>span:bgc" :$warning50
+                                                                                ">span:nth-child(4):c"         :$orange700
+                                                                                ">span:nth-child(4):>span:bgc" :$orange50
+                                                                                ">span:nth-child(5):c"         :$negative
+                                                                                ">span:nth-child(5):>span:bgc" :$negative50}})}])}]}
 
    {:fn       tooltip
     :meta     #'tooltip
@@ -286,20 +288,20 @@
                                                  :p--0.3em:0.6em!important)
                                      "This is an example tooltip"]])}]}
 
-   {:fn                   mui-icon
-    :meta                 #'mui-icon
-    :title                "Icons"
-    :stage                {:style {:min-height :135px}}
-    :controls             [:size]
-    :defaults             {:size :medium}
-    :desc                 ["Icons in Kushi are pulled in via [Google's Material Icons font for the web](https://developers.google.com/fonts/docs/material_icons#icon_font_for_the_web)."
-                           :br
-                           "Use [this page](https://fonts.google.com/icons?icon.set=Material+Icons) to explore over 1000+ different icons."
-                           :br
-                           :br
-                           "This component expects a child argument which is a string or keyword that correspondes to the name of an existing mui icon. If a string, snake case (underscores instead of spaces) must be used. If using a keyword, kebab (hyphens instead of spaces) case must be used."]
+   {:fn       mui-icon
+    :meta     #'mui-icon
+    :title    "Icons"
+    :stage    {:style {:min-height :135px}}
+    :controls [:size]
+    :defaults {:size :medium}
+    :desc     ["Icons in Kushi are pulled in via [Google's Material Icons font for the web](https://developers.google.com/fonts/docs/material_icons#icon_font_for_the_web)."
+               :br
+               "Use [this page](https://fonts.google.com/icons?icon.set=Material+Icons) to explore over 1000+ different icons."
+               :br
+               :br
+               "This component expects a child argument which is a string or keyword that correspondes to the name of an existing mui icon. If a string, snake case (underscores instead of spaces) must be used. If using a keyword, kebab (hyphens instead of spaces) case must be used."]
 
-    :content              icon-examples }
+    :content  icon-examples }
 
    {:fn       tag
     :meta     #'tag
@@ -378,6 +380,39 @@
                                              :text-shadow--1px:1px:5px:#9eef00b5
                                              :box-shadow--inset:0px:0px:40px:#9eef0073)
                                     [:span (sx :pis--7ex :letter-spacing--7ex) "alien"]])}]}
+
+
+   {:fn       alert
+    :meta     #'alert
+    :stage    {:style {:min-height :150px}}
+    :controls [:semantic :kind :size :shape :weight]
+    :defaults {:kind     :default
+               :shape    :sharp
+               :semantic :neutral
+               :size     :medium
+               :weight   :wee-bold
+               :examples "Default"}
+    :content  [{:label   "Default"
+                :example (example2 [alert
+                                    (sx :.accent
+                                        {:-mui-icon         :info-outline
+                                         :-close-icon?      true
+                                         :-close-icon-attrs {:on-click #(js/alert "Example close-icon click event.")}})
+                                    "Your message goes here."])}
+               {:label   "with fixed position"
+                :example (example2 [alert
+                                    (sx :.accent
+                                        :.fixed
+                                        :zi--100
+                                        :bottom--0
+                                        :left--0
+                                        :right--0
+                                        {:-mui-icon         :auto-awesome
+                                         :-mui-icon-style   :outlined
+                                         :-close-icon?      true
+                                         :-close-icon-attrs {:on-click #(js/alert "Example close-icon click event.")}})
+                                    "Your message goes here."])}
+               ]}
 
    {:fn       modal
     :meta     #'modal

--- a/src/kushi/ui/icon/helper.cljs
+++ b/src/kushi/ui/icon/helper.cljs
@@ -1,24 +1,18 @@
 (ns ^:dev/always kushi.ui.icon.helper
-  (:require-macros
-   [kushi.core :refer (defclass)])
   (:require
    [kushi.ui.icon.mui.core :refer (mui-icon mui-icon-outlined mui-icon-round mui-icon-two-tone mui-icon-sharp)]))
 
-(defclass kushi-icon-inline-start :mie--$icon-enhancer-inline-gap-ems)
-(defclass kushi-icon-inline-end :mis--$icon-enhancer-inline-gap-ems)
 
-(defn icon-component [{:keys [mi mui-icon-style icon-position no-margins? icon-svg]}]
+(defn icon-component
+  [{:keys [mi mui-icon-style icon-svg]}]
   (when mi
-    (let [component-class (when (and mi (not no-margins?))
-                            (if (= icon-position :inline-end) 'kushi-icon-inline-end 'kushi-icon-inline-start))
-          icon-component* (case mui-icon-style
+    (let [icon-component* (case mui-icon-style
                             :outlined mui-icon-outlined
                             :round mui-icon-round
                             :two-tone mui-icon-two-tone
                             :sharp mui-icon-sharp
                             mui-icon)
           icon-component  [icon-component*
-                           {:class      [component-class]
-                            :-icon-svg icon-svg}
+                           {:-icon-svg icon-svg}
                            mi]]
       icon-component)))

--- a/src/kushi/ui/label/core.cljs
+++ b/src/kushi/ui/label/core.cljs
@@ -36,22 +36,20 @@
                 mui-icon-style :filled
                 icon-position  :inline-start}} &opts
         icon-component (icon-component {:mi             mi
-                                        :icon-position  icon-position
                                         :mui-icon-style mui-icon-style
-                                        :icon-svg       icon-svg})
-        icon-class (when mi (str "kushi-label-with-icon-" (name icon-position))) ]
+                                        :icon-svg       icon-svg})]
 
     [:span
      (merge-attrs
       (sx 'kushi-label
           :.flex-row-c
+          :gap--$icon-enhancer-inline-gap-ems
           :.transition
           :ai--c
           :d--inline-flex
           :w--fit-content
           {:data-kushi-ui :label})
-      &attrs
-      {:class icon-class})
+      &attrs)
      (cond
        (and mi (= icon-position :inline-end))
        (conj &children icon-component)

--- a/src/kushi/utils.cljc
+++ b/src/kushi/utils.cljc
@@ -25,6 +25,25 @@
   (when (nameable? x)
     (some-> x name (string/starts-with? "--"))))
 
+(defn cssfn-string
+  "(cssfn-string \"hsla\" \"100deg\" \"50%\" \"33%\" \"0.8\")
+   => \"hsla(100deg, 50%, 33%, 0.8)\""
+  [s args]
+  (str s
+       "("
+       (string/join ", " args)
+       ")"))
+
+(defn extract-cssvar-name
+  "(extract-cssvar-name \"var(--red500)\")
+   => \"--red500\""
+  [%]
+  (when-let [[_ nm] (re-find (re-pattern (str "^"
+                                              specs2/cssvar-in-css-re
+                                              "$"))
+                             %)]
+    nm))
+
 (defn cssvar-dollar-syntax->double-dash
   [x]
   (string/replace (name x) #"^\$" "--"))


### PR DESCRIPTION
Closes #35

Also adds initial support for `kushi/transparentize` css function to transparentize colors defined in the design system.